### PR TITLE
doc: make the gitfile syntax easier to discover

### DIFF
--- a/Documentation/gitrepository-layout.txt
+++ b/Documentation/gitrepository-layout.txt
@@ -23,10 +23,10 @@ A Git repository comes in two different flavours:
 
 *Note*: Also you can have a plain text file `.git` at the root of
 your working tree, containing `gitdir: <path>` to point at the real
-directory that has the repository.  This mechanism is often used for
-a working tree of a submodule checkout, to allow you in the
-containing superproject to `git checkout` a branch that does not
-have the submodule.  The `checkout` has to remove the entire
+directory that has the repository.  This mechanism is called a 'gitfile'
+and is often used for a working tree of a submodule checkout, to allow
+you in the containing superproject to `git checkout` a branch that
+does not have the submodule.  The `checkout` has to remove the entire
 submodule working tree, without losing the submodule repository.
 
 These things may exist in a Git repository.

--- a/Documentation/glossary-content.txt
+++ b/Documentation/glossary-content.txt
@@ -184,6 +184,7 @@ current branch integrates with) obviously do not work, as there is no
 [[def_gitfile]]gitfile::
 	A plain file `.git` at the root of a working tree that
 	points at the directory that is the real repository.
+	See linkgit:gitrepository-layout for the syntax.
 
 [[def_grafts]]grafts::
 	Grafts enables two otherwise different lines of development to be joined


### PR DESCRIPTION
It took way too long for me to find the syntax expected for a gitfile. My search engine found the gitglossary manpage which defined the term but had no hints about syntax.
Thus here I add a mention of gitrepository-layout.

Once I somehow found gitrepository-layout, I searched for "gitfile" in there, but had no matches. It took a moment of discouragement and a minute or so of actually reading to find the info I was looking for. Thus here I add the part "[This mechanism is] called a 'gitfile'" in hopes that future readers will find it in mere seconds and without discouragement. Maybe it even helps search engines find it.

Ideally, someone else may add a mention of gitrepository-layout in the "fatal: invalid gitfile format:" error message, which is what sent me on my journey initially, or even add a stub man page named "gitfile".

Based on the maint branch for maximum compatibility.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
